### PR TITLE
Added adoc files for Charles and James Sparrell

### DIFF
--- a/priv/static/narrative/gen0/gen0..Charles_F_Sparrell.adoc
+++ b/priv/static/narrative/gen0/gen0..Charles_F_Sparrell.adoc
@@ -1,0 +1,9 @@
+= Charles Fisher Sparrell
+
+Born on October 26, 1928 in Worcester, Massachusetts. Died on September 25, 2007 in Scituate, Massachusetts. Son of link:https://github.com/sparrell/CfsJksAs/blob/main/priv/static/adoc/V2_C5_G1/gen1.P.Herbert_Kirkwood_Sparrell.adoc[Herbert K. Sparrell] and link:https://github.com/sparrell/CfsJksAs/blob/main/priv/static/adoc/V2_C5_G1/gen1.M.Marion_F_Fisher.adoc[Marion Fisher].
+
+Charles F Sparrell was an uncommonly gifted Civil Engineer who specialized in Loss Prevention and Safety Engineering. Upon graduating from Norwich University with the Class of 1949, he leveraged his Bachelor of Science degree in Civil Engineering into a position building bridges for the state of Maine. He transitioned to a role with Liberty Mutual Insurance Company where his strong reputation sustained and advanced his career until his eventual retirement as Assistant Vice President of Loss Prevention. 
+
+Among his many noteworthy professional contributions, Charles F Sparrell helped supervise the construction of the Gateway Arch in St. Louis, Missouri. That project enjoyed an accident rate twenty percent better than expected. So too, Charles F Sparrell was a pioneer in the scientific testing of automobile safety devices now considered industry standard. 
+
+In addition to his storied work life, Charles F Sparrell served honorably in the Army Reserve Corps of Engineers. Upon graduation, he was commissioned a second lieutenant and attached to an armored cavalry unit. In 1958, he was promoted to the rank of captain.

--- a/priv/static/narrative/gen0/gen0..James_K_Sparrell.adoc
+++ b/priv/static/narrative/gen0/gen0..James_K_Sparrell.adoc
@@ -1,0 +1,3 @@
+= James K Sparrell
+
+Born on March 11, 1932 in Wickford, Rhode Island. Died on September 17, 2015 in Damariscotta, Maine. Son of link:https://github.com/sparrell/CfsJksAs/blob/main/priv/static/adoc/V2_C5_G1/gen1.P.Herbert_Kirkwood_Sparrell.adoc[Herbert K. Sparrell] and link:https://github.com/sparrell/CfsJksAs/blob/main/priv/static/adoc/V2_C5_G1/gen1.M.Marion_F_Fisher.adoc[Marion Fisher].


### PR DESCRIPTION
Files were added in the narrative directory under gen0. Additionally, a basic framework for the biography of Charles F Sparrell was cobbled together from available sources.